### PR TITLE
Fixed line in comb

### DIFF
--- a/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.ipynb
+++ b/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,17 +21,18 @@
     "    for i in np.arange(0, nperm):\n",
     "        trt[i,] = np.random.choice(n, size=m, replace=False)\n",
     "\n",
-    "    Z = np.zeros((nperm,n))\n",
+    "    Z = np.zeros((nperm,n), dtype=int)\n",
+    "    \n",
     "    for i in np.arange(0, nperm):\n",
     "        Z[i,trt[i,]] = 1\n",
-    "        Z[i,-trt[i,]] = 0\n",
+    "        Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0\n",
     "\n",
     "    return Z"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.py
+++ b/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.py
@@ -8,10 +8,11 @@ def comb(n, m, nperm):
     for i in np.arange(0, nperm):
         trt[i,] = np.random.choice(n, size=m, replace=False)
 
-    Z = np.zeros((nperm,n))
+    Z = np.zeros((nperm,n), dtype=int)
+    
     for i in np.arange(0, nperm):
         Z[i,trt[i,]] = 1
-        Z[i,-trt[i,]] = 0
+        Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0
 
     return Z
 

--- a/jacqueline_translate_r_code.ipynb
+++ b/jacqueline_translate_r_code.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,17 +21,18 @@
     "    for i in np.arange(0, nperm):\n",
     "        trt[i,] = np.random.choice(n, size=m, replace=False)\n",
     "\n",
-    "    Z = np.zeros((nperm,n))\n",
+    "    Z = np.zeros((nperm,n), dtype=int)\n",
+    "    \n",
     "    for i in np.arange(0, nperm):\n",
     "        Z[i,trt[i,]] = 1\n",
-    "        Z[i,-trt[i,]] = 0\n",
+    "        Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0\n",
     "\n",
     "    return Z"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/jacqueline_translate_r_code.py
+++ b/jacqueline_translate_r_code.py
@@ -8,10 +8,11 @@ def comb(n, m, nperm):
     for i in np.arange(0, nperm):
         trt[i,] = np.random.choice(n, size=m, replace=False)
 
-    Z = np.zeros((nperm,n))
+    Z = np.zeros((nperm,n), dtype=int)
+    
     for i in np.arange(0, nperm):
         Z[i,trt[i,]] = 1
-        Z[i,-trt[i,]] = 0
+        Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0
 
     return Z
 


### PR DESCRIPTION
@sanakhad brought up the negative sign in the `Z[i,-trt[i,]] = 0` and I realized that I forgot to translate that part to python.

In the line `Z[i,-trt[i,]] = 1`, elements at the randomly chosen indices (from the previous for loop) are set to 1. The line `Z[i,-trt[i,]] = 0` sets all of the other values to 0.

In R, the negative sign makes it so you're setting all of the indices _except_ the ones in `trt[i,]`. This is what allows you to set all of the other values to 0.

This is different from the negative sign in python, which will tell python to index from the backwards instead of forward.
Nice catch! I didn't notice that the values weren't being set to 0 correctly bc i had initialized my matrix w/ 0 instead of NA.

I replaced the line with `Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0` which does the same thing in python, but I also realized that because I initialized the matrix with 0s, I don't even need this extra line to set the other values. I set a random seed and double checked to make sure this was true.

Still, this PR includes the changed line of code in case Sana needs to use it!