### PR TITLE
Fixed small bug in tau_twoside_lower

### DIFF
--- a/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.ipynb
+++ b/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.ipynb
@@ -7,14 +7,87 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import scipy.special"
+    "import pandas as pd\n",
+    "import math\n",
+    "from itertools import combinations\n",
+    "from itertools import filterfalse\n",
+    "import scipy.special\n",
+    "%load_ext rpy2.ipython"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "def nchoosem(n, m):\n",
+    "    \"\"\"blurb here\"\"\"\n",
+    "    c = math.comb(n, m)\n",
+    "    trt = np.array(list(combinations(np.arange(n), m)))\n",
+    "    Z = np.zeros((c, n))\n",
+    "    for i in np.arange(c):\n",
+    "        Z[i, trt[i, :]] = 1\n",
+    "    return Z"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[1., 1., 1., 0., 0.],\n",
+       "       [1., 1., 0., 1., 0.],\n",
+       "       [1., 1., 0., 0., 1.],\n",
+       "       [1., 0., 1., 1., 0.],\n",
+       "       [1., 0., 1., 0., 1.],\n",
+       "       [1., 0., 0., 1., 1.],\n",
+       "       [0., 1., 1., 1., 0.],\n",
+       "       [0., 1., 1., 0., 1.],\n",
+       "       [0., 1., 0., 1., 1.],\n",
+       "       [0., 0., 1., 1., 1.]])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = 5\n",
+    "m = 3\n",
+    "c = list(combinations(np.arange(5), 3))\n",
+    "nchoosem(n, m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0, 0, 1, 1, 1, 1, 0, 0, 0, 1],\n",
+       "       [0, 1, 1, 0, 1, 0, 1, 0, 1, 0],\n",
+       "       [1, 1, 0, 0, 1, 0, 1, 0, 1, 0],\n",
+       "       [0, 0, 1, 1, 1, 1, 0, 0, 1, 0],\n",
+       "       [1, 0, 0, 1, 0, 1, 1, 0, 0, 1],\n",
+       "       [0, 0, 1, 1, 1, 0, 0, 1, 0, 1],\n",
+       "       [1, 0, 0, 1, 0, 1, 0, 1, 1, 0],\n",
+       "       [1, 1, 1, 0, 0, 0, 1, 1, 0, 0],\n",
+       "       [0, 0, 0, 1, 1, 0, 1, 1, 1, 0],\n",
+       "       [0, 1, 1, 0, 0, 1, 1, 1, 0, 0]])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def comb(n, m, nperm):\n",
     "    trt = np.zeros((nperm,m), dtype=int)\n",
@@ -25,16 +98,247 @@
     "    \n",
     "    for i in np.arange(0, nperm):\n",
     "        Z[i,trt[i,]] = 1\n",
-    "        Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0\n",
     "\n",
-    "    return Z"
+    "    return Z\n",
+    "\n",
+    "comb(n, m, n)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.36507936507936506"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n11 = 4\n",
+    "n01 = 3\n",
+    "n00 = 2\n",
+    "n10 = 1\n",
+    "m = n10 + n11\n",
+    "n = n11 + n01 + n00 + n10\n",
+    "N11 = 3\n",
+    "Z_all = nchoosem(n, m)\n",
+    "tau_obs = n11/m - n01/(n-m)\n",
+    "\n",
+    "def pval_two(n, m, N, Z_all, tau_obs):\n",
+    "    n_Z_all = Z_all.shape[0]\n",
+    "    dat = np.zeros((n, 2))\n",
+    "    if N[0] > 0:\n",
+    "        dat[0:N[0], :] = 1\n",
+    "    if N[1] > 0:\n",
+    "        dat[(N[0]): (N[0] + N[1]), 0] = 1\n",
+    "        dat[(N[0]): (N[0] + N[1]), 1] = 0\n",
+    "    if N[2] > 0:\n",
+    "        dat[(N[0]+N[1]):(N[0]+N[1]+N[2]), 0] = 0\n",
+    "        dat[(N[0]+N[1]):(N[0]+N[1]+N[2]), 1] = 1\n",
+    "    if N[3] > 0:\n",
+    "        dat[(N[0]+N[1]+N[2]):(N[0]+N[1]+N[2]+N[3]), ] = 0\n",
+    "    tau_hat = np.matmul(Z_all, dat[:, 0])/(m) - np.matmul((1 - Z_all), dat[:, 1])/(n-m)\n",
+    "    tau_N = (N[1]-N[2])/n \n",
+    "    pd = sum(np.round(np.abs(tau_hat-tau_N),15)>=np.round(np.abs(tau_obs-tau_N),15))/n_Z_all\n",
+    "    return pd\n",
+    "\n",
+    "pval_two(n, m, np.array([1,2,3,4]), Z_all, tau_obs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[True, True]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def check_compatible(n11, n10, n01, n00, N11, N10, N01):\n",
+    "    n = n11 + n10 + n01 + n00\n",
+    "    n_t = len(N10)\n",
+    "    left = np.max(np.array([np.repeat(0, n_t), n11 - np.array(N10), np.array(N11) - n01, np.array(N11) + np.array(N01)-n10-n01]), axis=0)\n",
+    "    right = np.min(np.array([np.array(N11), np.repeat(n11, n_t), np.array(N11) + np.array(N01) - n01, n-np.array(N10)-n01-n10]), axis=0)\n",
+    "    compat = left <= right\n",
+    "    return list(compat)\n",
+    "\n",
+    "check_compatible(1, 5, 12, 13, np.array([5, 6]), np.array([6,8]), np.array([7, 8]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_min': -0.3,\n",
+       " 'tau_max': 0.2,\n",
+       " 'N_accept_min': array([3., 1., 4., 2.]),\n",
+       " 'N_accept_max': array([3., 3., 1., 3.]),\n",
+       " 'rand_test_num': 8}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, alpha):\n",
+    "    \"\"\"blurb here\"\"\"\n",
+    "    n = n11 + n10 + n01 + n00\n",
+    "    m = n11 + n10\n",
+    "    tau_obs = n11 / m - n01 / (n - m)\n",
+    "    ntau_obs = n * n11 / m - n * n01 / (n - m)\n",
+    "    # N01 range from max((-n*tau_obs),0) to n-N11\n",
+    "    N10 = 0\n",
+    "    N01_vec0 = np.arange(0, (n-N11))[np.arange(0, (n-N11)) >= (-ntau_obs)] #  check if c() is inclusive\n",
+    "    N01 = min(N01_vec0)\n",
+    "    M = np.repeat(np.nan, len(N01_vec0))\n",
+    "    ### need to change\n",
+    "    ### counting number of randomization test\n",
+    "    rand_test_num = 0\n",
+    "    while (N10 <= (n - N11 - N01) and N01 <= (n - N11)):\n",
+    "        if N10 <= (N01 + ntau_obs):\n",
+    "            pl = pval_two(n, m, np.array([N11, N10, N01, n - (N11 + N10 + N01)]), Z_all, tau_obs)\n",
+    "            rand_test_num += 1\n",
+    "            if pl >= alpha:\n",
+    "                M[N01_vec0 == N01] = N10\n",
+    "                N01 = N01 + 1\n",
+    "            else:\n",
+    "                N10 = N10 + 1\n",
+    "        else:\n",
+    "            M[N01_vec0 == N01] = N10\n",
+    "            N01 = N01 + 1\n",
+    "    if N01 <= (n - N11):\n",
+    "        M[N01_vec0 >= N01] = np.floor(N01_vec0[N01_vec0 >= N01] + ntau_obs) + 1\n",
+    "    N11_vec0 = np.repeat(N11, len(N01_vec0))\n",
+    "    N10_vec0 = M\n",
+    "    N11_vec = np.array([])\n",
+    "    N10_vec = np.array([])\n",
+    "    N01_vec = np.array([])\n",
+    "    for i in np.arange(len(N11_vec0)):\n",
+    "        N10_upper = min((n - N11_vec0[i] - N01_vec0[i]), np.floor(N01_vec0[i] + ntau_obs))\n",
+    "        if N10_vec0[i] <= N10_upper:\n",
+    "            N10_vec = np.append(N10_vec, np.array(np.arange(N10_vec0[i], N10_upper + 1)))\n",
+    "            N11_vec = np.append(N11_vec, np.repeat(N11_vec0[i], (N10_upper-N10_vec0[i]+1)))\n",
+    "            N01_vec = np.append(N01_vec, np.repeat(N01_vec0[i], (N10_upper-N10_vec0[i]+1)))\n",
+    "\n",
+    "    compat = check_compatible(n11, n10, n01, n00, N11_vec, N10_vec, N01_vec)\n",
+    "    \n",
+    "    if sum(compat) > 0:\n",
+    "        tau_min = min(N10_vec[compat] - N01_vec[compat]) / n\n",
+    "        accept_pos = np.where((N10_vec[compat] - N01_vec[compat]) == n * tau_min)\n",
+    "        accept_pos = accept_pos[0]\n",
+    "        N_accept_min = np.array([N11, N10_vec[compat][accept_pos][0], N01_vec[compat][accept_pos][0], n-(N11+N10_vec[compat][accept_pos]+N01_vec[compat][accept_pos])[0]])\n",
+    "        tau_max = max(N10_vec[compat] - N01_vec[compat]) / n\n",
+    "        accept_pos = np.where((N10_vec[compat] - N01_vec[compat]) == n * tau_max)\n",
+    "        accept_pos = accept_pos[0]\n",
+    "        N_accept_max = np.array([N11, N10_vec[compat][accept_pos][0], N01_vec[compat][accept_pos][0], n-(N11+N10_vec[compat][accept_pos]+N01_vec[compat][accept_pos])[0]])\n",
+    "    else:\n",
+    "        tau_min = math.inf\n",
+    "        N_accept_min = np.nan\n",
+    "        tau_max = -math.inf\n",
+    "        N_accept_max = np.nan\n",
+    "    return {\"tau_min\": tau_min, \"tau_max\": tau_max, \"N_accept_min\": N_accept_min, \"N_accept_max\":N_accept_max, \"rand_test_num\":rand_test_num}\n",
+    "\n",
+    "\n",
+    "tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, .05)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_lower': -0.3,\n",
+       " 'N_accept_lower': array([3., 1., 4., 2.]),\n",
+       " 'tau_upper': 0.2,\n",
+       " 'N_accept_upper': array([0., 5., 3., 2.]),\n",
+       " 'rand_test_total': 60}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def tau_twoside_lower(n11, n10, n01, n00, alpha, Z_all):\n",
+    "    n = n11+n10+n01+n00\n",
+    "    m = n11+n10\n",
+    "    tau_obs = n11/m - n01/(n-m)\n",
+    "    ntau_obs = n*n11/m - n* n01/(n-m)\n",
+    "    tau_min = math.inf\n",
+    "    tau_max = -math.inf\n",
+    "    N_accept_min = np.nan\n",
+    "    N_accept_max = np.nan\n",
+    "    rand_test_total = 0\n",
+    "    \n",
+    "    for N11 in np.arange(0, min((n11+n01), n+ntau_obs)+1):\n",
+    "        tau_min_N11 = tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, alpha)\n",
+    "        # assumes that tau_lower_N11_twoside output is a dictionary\n",
+    "        rand_test_total = rand_test_total + tau_min_N11[\"rand_test_num\"] \n",
+    "        if(tau_min_N11[\"tau_min\"] < tau_min):\n",
+    "            N_accept_min = tau_min_N11[\"N_accept_min\"]\n",
+    "        if(tau_min_N11[\"tau_max\"] > tau_max):\n",
+    "            N_accept_max = tau_min_N11[\"N_accept_max\"]\n",
+    "        tau_min = min(tau_min, tau_min_N11[\"tau_min\"])\n",
+    "        tau_max = max(tau_max, tau_min_N11[\"tau_max\"])\n",
+    "    \n",
+    "    tau_lower = tau_min\n",
+    "    tau_upper = tau_max\n",
+    "    N_accept_lower = N_accept_min\n",
+    "    N_accept_upper = N_accept_max \n",
+    "                      \n",
+    "    dict_output = {'tau_lower':tau_lower, 'N_accept_lower':N_accept_lower, \n",
+    "                   'tau_upper':tau_upper, 'N_accept_upper':N_accept_upper,\n",
+    "                  'rand_test_total':rand_test_total}\n",
+    "    return dict_output\n",
+    "\n",
+    "tau_twoside_lower(n11, n10, n01, n00, 0.05, Z_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_lower': -0.2,\n",
+       " 'tau_upper': 0.5,\n",
+       " 'N_accept_lower': array([2., 2., 4., 2.]),\n",
+       " 'N_accept_upper': array([4., 5., 0., 1.]),\n",
+       " 'rand_test_total': 90}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def tau_twoside_less_treated(n11, n10, n01, n00, alpha, nperm):\n",
     "    n = n11 + n10 + n01 + n00\n",
@@ -67,14 +371,31 @@
     "    else:\n",
     "        N_accept_upper = ci_lower[\"N_accept_upper\"]\n",
     "\n",
-    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper,  \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}"
+    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper,  \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}\n",
+    "\n",
+    "tau_twoside_less_treated(n11, n10, n01, n00, 0.05, n)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_lower': -0.3,\n",
+       " 'tau_upper': 0.6,\n",
+       " 'N_accept_lower': array([3., 1., 4., 2.]),\n",
+       " 'N_accept_upper': array([3., 6., 0., 1.]),\n",
+       " 'rand_test_total': 90}"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def tau_twoside(n11, n10, n01, n00, alpha, nperm):\n",
     "    n = n11 + n10 + n01 + n00\n",
@@ -94,7 +415,9 @@
     "        N_accept_upper = ci[\"N_accept_upper\"]\n",
     "        rand_test_total = ci[\"rand_test_total\"]\n",
     "\n",
-    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper, \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}"
+    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper, \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}\n",
+    "\n",
+    "tau_twoside(n11, n10, n01, n00, 0.05, n)"
    ]
   }
  ],

--- a/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.py
+++ b/.ipynb_checkpoints/jacqueline_translate_r_code-checkpoint.py
@@ -17,6 +17,39 @@ def comb(n, m, nperm):
     return Z
 
 
+def tau_twoside_lower(n11, n10, n01, n00, alpha, Z_all):
+    n = n11+n10+n01+n00
+    m = n11+n10
+    tau_obs = n11/m - n01/(n-m)
+    ntau_obs = n*n11/m - n* n01/(n-m)
+    tau_min = math.inf
+    tau_max = -math.inf
+    N_accept_min = np.nan
+    N_accept_max = np.nan
+    rand_test_total = 0
+    
+    for N11 in np.arange(0, min((n11+n01), n+ntau_obs)+1):
+        tau_min_N11 = tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, alpha)
+        # assumes that tau_lower_N11_twoside output is a dictionary
+        rand_test_total = rand_test_total + tau_min_N11["rand_test_num"] 
+        if(tau_min_N11["tau_min"] < tau_min):
+            N_accept_min = tau_min_N11["N_accept_min"]
+        if(tau_min_N11["tau_max"] > tau_max):
+            N_accept_max = tau_min_N11["N_accept_max"]
+        tau_min = min(tau_min, tau_min_N11["tau_min"])
+        tau_max = max(tau_max, tau_min_N11["tau_max"])
+    
+    tau_lower = tau_min
+    tau_upper = tau_max
+    N_accept_lower = N_accept_min
+    N_accept_upper = N_accept_max 
+                      
+    dict_output = {'tau_lower':tau_lower, 'N_accept_lower':N_accept_lower, 
+                   'tau_upper':tau_upper, 'N_accept_upper':N_accept_upper,
+                  'rand_test_total':rand_test_total}
+    return dict_output
+
+
 def tau_twoside_less_treated(n11, n10, n01, n00, alpha, nperm):
     n = n11 + n10 + n01 + n00
     m = n11 + n10

--- a/jacqueline_translate_r_code.ipynb
+++ b/jacqueline_translate_r_code.ipynb
@@ -7,14 +7,87 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import scipy.special"
+    "import pandas as pd\n",
+    "import math\n",
+    "from itertools import combinations\n",
+    "from itertools import filterfalse\n",
+    "import scipy.special\n",
+    "%load_ext rpy2.ipython"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "def nchoosem(n, m):\n",
+    "    \"\"\"blurb here\"\"\"\n",
+    "    c = math.comb(n, m)\n",
+    "    trt = np.array(list(combinations(np.arange(n), m)))\n",
+    "    Z = np.zeros((c, n))\n",
+    "    for i in np.arange(c):\n",
+    "        Z[i, trt[i, :]] = 1\n",
+    "    return Z"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[1., 1., 1., 0., 0.],\n",
+       "       [1., 1., 0., 1., 0.],\n",
+       "       [1., 1., 0., 0., 1.],\n",
+       "       [1., 0., 1., 1., 0.],\n",
+       "       [1., 0., 1., 0., 1.],\n",
+       "       [1., 0., 0., 1., 1.],\n",
+       "       [0., 1., 1., 1., 0.],\n",
+       "       [0., 1., 1., 0., 1.],\n",
+       "       [0., 1., 0., 1., 1.],\n",
+       "       [0., 0., 1., 1., 1.]])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = 5\n",
+    "m = 3\n",
+    "c = list(combinations(np.arange(5), 3))\n",
+    "nchoosem(n, m)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0, 0, 1, 1, 1, 1, 0, 0, 0, 1],\n",
+       "       [0, 1, 1, 0, 1, 0, 1, 0, 1, 0],\n",
+       "       [1, 1, 0, 0, 1, 0, 1, 0, 1, 0],\n",
+       "       [0, 0, 1, 1, 1, 1, 0, 0, 1, 0],\n",
+       "       [1, 0, 0, 1, 0, 1, 1, 0, 0, 1],\n",
+       "       [0, 0, 1, 1, 1, 0, 0, 1, 0, 1],\n",
+       "       [1, 0, 0, 1, 0, 1, 0, 1, 1, 0],\n",
+       "       [1, 1, 1, 0, 0, 0, 1, 1, 0, 0],\n",
+       "       [0, 0, 0, 1, 1, 0, 1, 1, 1, 0],\n",
+       "       [0, 1, 1, 0, 0, 1, 1, 1, 0, 0]])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def comb(n, m, nperm):\n",
     "    trt = np.zeros((nperm,m), dtype=int)\n",
@@ -25,16 +98,247 @@
     "    \n",
     "    for i in np.arange(0, nperm):\n",
     "        Z[i,trt[i,]] = 1\n",
-    "        Z[i,(~np.in1d(np.arange(Z.shape[1]), trt[i,])).nonzero()] = 0\n",
     "\n",
-    "    return Z"
+    "    return Z\n",
+    "\n",
+    "comb(n, m, n)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.36507936507936506"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n11 = 4\n",
+    "n01 = 3\n",
+    "n00 = 2\n",
+    "n10 = 1\n",
+    "m = n10 + n11\n",
+    "n = n11 + n01 + n00 + n10\n",
+    "N11 = 3\n",
+    "Z_all = nchoosem(n, m)\n",
+    "tau_obs = n11/m - n01/(n-m)\n",
+    "\n",
+    "def pval_two(n, m, N, Z_all, tau_obs):\n",
+    "    n_Z_all = Z_all.shape[0]\n",
+    "    dat = np.zeros((n, 2))\n",
+    "    if N[0] > 0:\n",
+    "        dat[0:N[0], :] = 1\n",
+    "    if N[1] > 0:\n",
+    "        dat[(N[0]): (N[0] + N[1]), 0] = 1\n",
+    "        dat[(N[0]): (N[0] + N[1]), 1] = 0\n",
+    "    if N[2] > 0:\n",
+    "        dat[(N[0]+N[1]):(N[0]+N[1]+N[2]), 0] = 0\n",
+    "        dat[(N[0]+N[1]):(N[0]+N[1]+N[2]), 1] = 1\n",
+    "    if N[3] > 0:\n",
+    "        dat[(N[0]+N[1]+N[2]):(N[0]+N[1]+N[2]+N[3]), ] = 0\n",
+    "    tau_hat = np.matmul(Z_all, dat[:, 0])/(m) - np.matmul((1 - Z_all), dat[:, 1])/(n-m)\n",
+    "    tau_N = (N[1]-N[2])/n \n",
+    "    pd = sum(np.round(np.abs(tau_hat-tau_N),15)>=np.round(np.abs(tau_obs-tau_N),15))/n_Z_all\n",
+    "    return pd\n",
+    "\n",
+    "pval_two(n, m, np.array([1,2,3,4]), Z_all, tau_obs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[True, True]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def check_compatible(n11, n10, n01, n00, N11, N10, N01):\n",
+    "    n = n11 + n10 + n01 + n00\n",
+    "    n_t = len(N10)\n",
+    "    left = np.max(np.array([np.repeat(0, n_t), n11 - np.array(N10), np.array(N11) - n01, np.array(N11) + np.array(N01)-n10-n01]), axis=0)\n",
+    "    right = np.min(np.array([np.array(N11), np.repeat(n11, n_t), np.array(N11) + np.array(N01) - n01, n-np.array(N10)-n01-n10]), axis=0)\n",
+    "    compat = left <= right\n",
+    "    return list(compat)\n",
+    "\n",
+    "check_compatible(1, 5, 12, 13, np.array([5, 6]), np.array([6,8]), np.array([7, 8]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_min': -0.3,\n",
+       " 'tau_max': 0.2,\n",
+       " 'N_accept_min': array([3., 1., 4., 2.]),\n",
+       " 'N_accept_max': array([3., 3., 1., 3.]),\n",
+       " 'rand_test_num': 8}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, alpha):\n",
+    "    \"\"\"blurb here\"\"\"\n",
+    "    n = n11 + n10 + n01 + n00\n",
+    "    m = n11 + n10\n",
+    "    tau_obs = n11 / m - n01 / (n - m)\n",
+    "    ntau_obs = n * n11 / m - n * n01 / (n - m)\n",
+    "    # N01 range from max((-n*tau_obs),0) to n-N11\n",
+    "    N10 = 0\n",
+    "    N01_vec0 = np.arange(0, (n-N11))[np.arange(0, (n-N11)) >= (-ntau_obs)] #  check if c() is inclusive\n",
+    "    N01 = min(N01_vec0)\n",
+    "    M = np.repeat(np.nan, len(N01_vec0))\n",
+    "    ### need to change\n",
+    "    ### counting number of randomization test\n",
+    "    rand_test_num = 0\n",
+    "    while (N10 <= (n - N11 - N01) and N01 <= (n - N11)):\n",
+    "        if N10 <= (N01 + ntau_obs):\n",
+    "            pl = pval_two(n, m, np.array([N11, N10, N01, n - (N11 + N10 + N01)]), Z_all, tau_obs)\n",
+    "            rand_test_num += 1\n",
+    "            if pl >= alpha:\n",
+    "                M[N01_vec0 == N01] = N10\n",
+    "                N01 = N01 + 1\n",
+    "            else:\n",
+    "                N10 = N10 + 1\n",
+    "        else:\n",
+    "            M[N01_vec0 == N01] = N10\n",
+    "            N01 = N01 + 1\n",
+    "    if N01 <= (n - N11):\n",
+    "        M[N01_vec0 >= N01] = np.floor(N01_vec0[N01_vec0 >= N01] + ntau_obs) + 1\n",
+    "    N11_vec0 = np.repeat(N11, len(N01_vec0))\n",
+    "    N10_vec0 = M\n",
+    "    N11_vec = np.array([])\n",
+    "    N10_vec = np.array([])\n",
+    "    N01_vec = np.array([])\n",
+    "    for i in np.arange(len(N11_vec0)):\n",
+    "        N10_upper = min((n - N11_vec0[i] - N01_vec0[i]), np.floor(N01_vec0[i] + ntau_obs))\n",
+    "        if N10_vec0[i] <= N10_upper:\n",
+    "            N10_vec = np.append(N10_vec, np.array(np.arange(N10_vec0[i], N10_upper + 1)))\n",
+    "            N11_vec = np.append(N11_vec, np.repeat(N11_vec0[i], (N10_upper-N10_vec0[i]+1)))\n",
+    "            N01_vec = np.append(N01_vec, np.repeat(N01_vec0[i], (N10_upper-N10_vec0[i]+1)))\n",
+    "\n",
+    "    compat = check_compatible(n11, n10, n01, n00, N11_vec, N10_vec, N01_vec)\n",
+    "    \n",
+    "    if sum(compat) > 0:\n",
+    "        tau_min = min(N10_vec[compat] - N01_vec[compat]) / n\n",
+    "        accept_pos = np.where((N10_vec[compat] - N01_vec[compat]) == n * tau_min)\n",
+    "        accept_pos = accept_pos[0]\n",
+    "        N_accept_min = np.array([N11, N10_vec[compat][accept_pos][0], N01_vec[compat][accept_pos][0], n-(N11+N10_vec[compat][accept_pos]+N01_vec[compat][accept_pos])[0]])\n",
+    "        tau_max = max(N10_vec[compat] - N01_vec[compat]) / n\n",
+    "        accept_pos = np.where((N10_vec[compat] - N01_vec[compat]) == n * tau_max)\n",
+    "        accept_pos = accept_pos[0]\n",
+    "        N_accept_max = np.array([N11, N10_vec[compat][accept_pos][0], N01_vec[compat][accept_pos][0], n-(N11+N10_vec[compat][accept_pos]+N01_vec[compat][accept_pos])[0]])\n",
+    "    else:\n",
+    "        tau_min = math.inf\n",
+    "        N_accept_min = np.nan\n",
+    "        tau_max = -math.inf\n",
+    "        N_accept_max = np.nan\n",
+    "    return {\"tau_min\": tau_min, \"tau_max\": tau_max, \"N_accept_min\": N_accept_min, \"N_accept_max\":N_accept_max, \"rand_test_num\":rand_test_num}\n",
+    "\n",
+    "\n",
+    "tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, .05)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_lower': -0.3,\n",
+       " 'N_accept_lower': array([3., 1., 4., 2.]),\n",
+       " 'tau_upper': 0.2,\n",
+       " 'N_accept_upper': array([0., 5., 3., 2.]),\n",
+       " 'rand_test_total': 60}"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def tau_twoside_lower(n11, n10, n01, n00, alpha, Z_all):\n",
+    "    n = n11+n10+n01+n00\n",
+    "    m = n11+n10\n",
+    "    tau_obs = n11/m - n01/(n-m)\n",
+    "    ntau_obs = n*n11/m - n* n01/(n-m)\n",
+    "    tau_min = math.inf\n",
+    "    tau_max = -math.inf\n",
+    "    N_accept_min = np.nan\n",
+    "    N_accept_max = np.nan\n",
+    "    rand_test_total = 0\n",
+    "    \n",
+    "    for N11 in np.arange(0, min((n11+n01), n+ntau_obs)+1):\n",
+    "        tau_min_N11 = tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, alpha)\n",
+    "        # assumes that tau_lower_N11_twoside output is a dictionary\n",
+    "        rand_test_total = rand_test_total + tau_min_N11[\"rand_test_num\"] \n",
+    "        if(tau_min_N11[\"tau_min\"] < tau_min):\n",
+    "            N_accept_min = tau_min_N11[\"N_accept_min\"]\n",
+    "        if(tau_min_N11[\"tau_max\"] > tau_max):\n",
+    "            N_accept_max = tau_min_N11[\"N_accept_max\"]\n",
+    "        tau_min = min(tau_min, tau_min_N11[\"tau_min\"])\n",
+    "        tau_max = max(tau_max, tau_min_N11[\"tau_max\"])\n",
+    "    \n",
+    "    tau_lower = tau_min\n",
+    "    tau_upper = tau_max\n",
+    "    N_accept_lower = N_accept_min\n",
+    "    N_accept_upper = N_accept_max \n",
+    "                      \n",
+    "    dict_output = {'tau_lower':tau_lower, 'N_accept_lower':N_accept_lower, \n",
+    "                   'tau_upper':tau_upper, 'N_accept_upper':N_accept_upper,\n",
+    "                  'rand_test_total':rand_test_total}\n",
+    "    return dict_output\n",
+    "\n",
+    "tau_twoside_lower(n11, n10, n01, n00, 0.05, Z_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_lower': -0.2,\n",
+       " 'tau_upper': 0.5,\n",
+       " 'N_accept_lower': array([2., 2., 4., 2.]),\n",
+       " 'N_accept_upper': array([4., 5., 0., 1.]),\n",
+       " 'rand_test_total': 90}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def tau_twoside_less_treated(n11, n10, n01, n00, alpha, nperm):\n",
     "    n = n11 + n10 + n01 + n00\n",
@@ -67,14 +371,31 @@
     "    else:\n",
     "        N_accept_upper = ci_lower[\"N_accept_upper\"]\n",
     "\n",
-    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper,  \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}"
+    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper,  \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}\n",
+    "\n",
+    "tau_twoside_less_treated(n11, n10, n01, n00, 0.05, n)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'tau_lower': -0.3,\n",
+       " 'tau_upper': 0.6,\n",
+       " 'N_accept_lower': array([3., 1., 4., 2.]),\n",
+       " 'N_accept_upper': array([3., 6., 0., 1.]),\n",
+       " 'rand_test_total': 90}"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def tau_twoside(n11, n10, n01, n00, alpha, nperm):\n",
     "    n = n11 + n10 + n01 + n00\n",
@@ -94,7 +415,9 @@
     "        N_accept_upper = ci[\"N_accept_upper\"]\n",
     "        rand_test_total = ci[\"rand_test_total\"]\n",
     "\n",
-    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper, \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}"
+    "    return {\"tau_lower\": tau_lower, \"tau_upper\": tau_upper, \"N_accept_lower\": N_accept_lower, \"N_accept_upper\": N_accept_upper, \"rand_test_total\": rand_test_total}\n",
+    "\n",
+    "tau_twoside(n11, n10, n01, n00, 0.05, n)"
    ]
   }
  ],

--- a/jacqueline_translate_r_code.py
+++ b/jacqueline_translate_r_code.py
@@ -17,6 +17,39 @@ def comb(n, m, nperm):
     return Z
 
 
+def tau_twoside_lower(n11, n10, n01, n00, alpha, Z_all):
+    n = n11+n10+n01+n00
+    m = n11+n10
+    tau_obs = n11/m - n01/(n-m)
+    ntau_obs = n*n11/m - n* n01/(n-m)
+    tau_min = math.inf
+    tau_max = -math.inf
+    N_accept_min = np.nan
+    N_accept_max = np.nan
+    rand_test_total = 0
+    
+    for N11 in np.arange(0, min((n11+n01), n+ntau_obs)+1):
+        tau_min_N11 = tau_lower_N11_twoside(n11, n10, n01, n00, N11, Z_all, alpha)
+        # assumes that tau_lower_N11_twoside output is a dictionary
+        rand_test_total = rand_test_total + tau_min_N11["rand_test_num"] 
+        if(tau_min_N11["tau_min"] < tau_min):
+            N_accept_min = tau_min_N11["N_accept_min"]
+        if(tau_min_N11["tau_max"] > tau_max):
+            N_accept_max = tau_min_N11["N_accept_max"]
+        tau_min = min(tau_min, tau_min_N11["tau_min"])
+        tau_max = max(tau_max, tau_min_N11["tau_max"])
+    
+    tau_lower = tau_min
+    tau_upper = tau_max
+    N_accept_lower = N_accept_min
+    N_accept_upper = N_accept_max 
+                      
+    dict_output = {'tau_lower':tau_lower, 'N_accept_lower':N_accept_lower, 
+                   'tau_upper':tau_upper, 'N_accept_upper':N_accept_upper,
+                  'rand_test_total':rand_test_total}
+    return dict_output
+
+
 def tau_twoside_less_treated(n11, n10, n01, n00, alpha, nperm):
     n = n11 + n10 + n01 + n00
     m = n11 + n10


### PR DESCRIPTION
When playing around with test inputs, I noticed that the `rand_test_total` was off when `tau_twoside_lower`, `tau_twoside_less_treated`, and `tau_twoside` were called. Added `+1` to line in `tau_twoside_lower`:
`for N11 in np.arange(0, min((n11+n01), n+ntau_obs)+1):`